### PR TITLE
removing an unused variable

### DIFF
--- a/StoreHours.class.php
+++ b/StoreHours.class.php
@@ -11,7 +11,7 @@
 
 class StoreHours {
 
-  function __construct($hours, $exceptions, $template, $settings) {
+  function __construct($hours, $exceptions, $template) {
     $this->hours = $hours;
     $this->exceptions = $exceptions;
     $this->template = $template;


### PR DESCRIPTION
variable $settings isnt mentioned or used anywhere, gives error at init
